### PR TITLE
fix for absolute-relative paths

### DIFF
--- a/Cruncher/Helpers/ResourceHelper.cs
+++ b/Cruncher/Helpers/ResourceHelper.cs
@@ -72,11 +72,12 @@ namespace Cruncher.Helpers
                         // If it is a relative path then combines the request's path with the resource's path
                         if (!Path.IsPathRooted(resource))
                         {
-                            return Path.GetFullPath(Path.Combine(rootPath, resource));
+                            string path = Path.GetFullPath(Path.Combine(rootPath, resource));
+                            return HostingEnvironment.MapPath(string.Format("~{0}", path));
                         }
 
                         // It is an absolute path
-                        return resource;
+                        return HostingEnvironment.MapPath(string.Format("~{0}", resource));
                     }
                 }
 

--- a/Cruncher/Preprocessors/ResourcePreprocessor.cs
+++ b/Cruncher/Preprocessors/ResourcePreprocessor.cs
@@ -124,7 +124,7 @@ namespace Cruncher.Preprocessors
 
                     // Parse the Absolute path.
                     Uri resolvedSourcePath = !isExternal
-                                            ? new Uri(this.GetAbsolutePathFromRelative(sourceDirectory, capturedRelativePath))
+                                            ? new Uri(Path.Combine(sourceDirectory, capturedRelativePath))
                                             : new Uri(new Uri(sourceDirectory, UriKind.Absolute), new Uri(capturedRelativePath, UriKind.Relative));
 
                     // Make it relative.
@@ -154,43 +154,6 @@ namespace Cruncher.Preprocessors
             }
 
             return input;
-        }
-
-        /// <summary>
-        /// Returns the absolute path to the relative resource.
-        /// </summary>
-        /// <param name="sourceDirectory">
-        /// The source directory to parse against.
-        /// </param>
-        /// <param name="relativePath">
-        /// The relative path.
-        /// </param>
-        /// <returns>
-        /// The <see cref="string"/> representing the absolute path to the file.
-        /// </returns>
-        private string GetAbsolutePathFromRelative(string sourceDirectory, string relativePath)
-        {
-            if (!relativePath.StartsWith(".."))
-            {
-                return Path.GetFullPath(Path.Combine(sourceDirectory, relativePath));
-            }
-
-            DirectoryInfo directoryInfo = new DirectoryInfo(sourceDirectory);
-
-            // Path is always propagated.
-            // ReSharper disable once PossibleNullReferenceException
-            string directoryName = Path.GetDirectoryName(relativePath).TrimStart(new[] { '.', '\\' });
-            string fileName = Path.GetFileName(relativePath);
-            // ReSharper disable once LoopCanBeConvertedToQuery
-            foreach (DirectoryInfo directory in directoryInfo.EnumerateDirectories(directoryName, SearchOption.AllDirectories))
-            {
-                foreach (FileInfo file in directory.EnumerateFiles(fileName, SearchOption.AllDirectories))
-                {
-                    return file.FullName;
-                }
-            }
-
-            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
With the fix everything is working fine.
I took a look at the GetAbsolutePathFromRelative() method but didn't see why it is necessary. Is there a case for which we need it? 
