### PR TITLE
Bugfix: CreateAllowedExtensionRegex

### DIFF
--- a/Cruncher/Preprocessors/PreprocessorManager.cs
+++ b/Cruncher/Preprocessors/PreprocessorManager.cs
@@ -189,7 +189,7 @@ namespace Cruncher.Preprocessors
                 }
             }
 
-            this.AllowedExtensionsRegex = new Regex(stringBuilder.ToString().TrimEnd('|'), RegexOptions.IgnoreCase);
+            this.AllowedExtensionsRegex = new Regex(string.Format("({0})$", stringBuilder.ToString().TrimEnd('|')), RegexOptions.IgnoreCase);
         }
         #endregion
     }


### PR DESCRIPTION
The regular expression shouldn't allow extensions like .js2, .jsd,
.css7, .cssz1