### PR TITLE
Fix for the cache dependencies (file monitors) bug

### DIFF
--- a/Cruncher/Web/CssHandler.cs
+++ b/Cruncher/Web/CssHandler.cs
@@ -12,11 +12,13 @@ namespace Cruncher.Web
 {
     #region Using
 
+    using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Runtime.Caching;
     using System.Text;
     using System.Web;
     using Cruncher.Caching;
@@ -95,6 +97,10 @@ namespace Cruncher.Web
 
                     this.cssCruncher = new CssCruncher(cruncherOptions);
 
+                    // When there is more than one file it is necessary to keep track of the cache Key for every file in order to allow 
+                    // allow the cache manager to retrieve all cached FileMonitors.
+                    ConcurrentBag<string> resourceFilesKeys = new ConcurrentBag<string>();
+
                     // Loop through and process each file.
                     foreach (string cssFile in cssFiles)
                     {
@@ -137,6 +143,9 @@ namespace Cruncher.Web
                                 string first = files.FirstOrDefault();
                                 cruncherOptions.RootFolder = Path.GetDirectoryName(first);
                                 stringBuilder.Append(this.cssCruncher.Crunch(first));
+
+                                // Store the file's key
+                                resourceFilesKeys.Add(first.ToMd5Fingerprint());
                             }
                         }
                         else
@@ -144,7 +153,20 @@ namespace Cruncher.Web
                             // Remote files.
                             string remoteFile = this.GetUrlFromToken(cssFile).ToString();
                             stringBuilder.Append(this.cssCruncher.Crunch(remoteFile));
+
+                            // Store the file's key
+                            resourceFilesKeys.Add(remoteFile.ToMd5Fingerprint());
                         }
+                    }
+
+                    // Store in cache the Resource Files Keys
+                    if (resourceFilesKeys.Count > 1)
+                    {
+                        CacheItemPolicy cacheItemPolicy = new CacheItemPolicy();
+                        int days = cruncherOptions.CacheLength;
+                        cacheItemPolicy.AbsoluteExpiration = DateTime.UtcNow.AddDays(days != 0 ? days : -1);
+                        cacheItemPolicy.Priority = CacheItemPriority.NotRemovable;
+                        CacheManager.AddItem(key + "_FILE_MONITOR_KEYS", resourceFilesKeys, cacheItemPolicy);
                     }
 
                     combinedCSS = this.cssCruncher.Minify(stringBuilder.ToString());


### PR DESCRIPTION
This is a quick fix for the cache dependencies (FileMonitors) bug. I
have tested it, but not exhaustively (tomorrow I will do more testing).
I have committed changes so you can have a look and tell me your
thoughts about it. There is probably another way to fix it (maybe
better), but this way implies modifying the source code to a minimum.
