### PR TITLE
Allow to disable the cleanup process

### DIFF
--- a/Cruncher/Web/Configuration/CruncherProcessingSection.cs
+++ b/Cruncher/Web/Configuration/CruncherProcessingSection.cs
@@ -191,7 +191,7 @@ namespace Cruncher.Web.Configuration
             /// </summary>
             /// <value>The number of days</value>
             [ConfigurationProperty("daysBeforeRemoveExpired", DefaultValue = "7", IsRequired = false)]
-            [IntegerValidator(ExcludeRange = false, MinValue = 1)]
+            [IntegerValidator(ExcludeRange = false)]
             public int DaysBeforeRemoveExpired
             {
                 get


### PR DESCRIPTION
Users can disable the cleanup process (files won't be deleted) by
setting a negative or 0 value to the daysBeforeRemoveExpired parameter
(web.config)
